### PR TITLE
Update release version to 0.16.2 in metadata

### DIFF
--- a/modules/neovide/dev.neovide.neovide.metainfo.xml
+++ b/modules/neovide/dev.neovide.neovide.metainfo.xml
@@ -34,8 +34,8 @@
   <url type="faq">https://neovide.dev/faq.html</url>
   <url type="vcs-browser">https://github.com/neovide/neovide</url>
   <releases>
-    <release date="2024-07-16" version="0.15.1">
-      <url type="details">https://github.com/neovide/neovide/releases/tag/0.15.1</url>
+    <release date="2024-07-16" version="0.16.2">
+      <url type="details">https://github.com/neovide/neovide/releases/tag/0.16.2</url>
     </release>
   </releases>
   <screenshots>


### PR DESCRIPTION
I just noticed this discrepancy after installing the latest flatpak.  I would assume this is supposed to be updated by a script, but it apparently didn't happen.